### PR TITLE
Lazily inject request content into operation manager

### DIFF
--- a/src/PatchManager/Bundle/RequestAdapter/RequestStackAdapter.php
+++ b/src/PatchManager/Bundle/RequestAdapter/RequestStackAdapter.php
@@ -22,10 +22,15 @@ class RequestStackAdapter implements Adapter
     }
 
     /**
-     * @param Operations $operations
+     * @return null|string
      */
-    public function setRequestBody(Operations $operations)
+    public function getRequestBody(): ?string
     {
-        $operations->setRequestBody($this->requestStack->getCurrentRequest()->getContent());
+        $request = $this->requestStack->getCurrentRequest();
+        if (is_null($request)) {
+            return null;
+        }
+
+        return $request->getContent();
     }
 }

--- a/src/PatchManager/Bundle/Resources/config/services.xml
+++ b/src/PatchManager/Bundle/Resources/config/services.xml
@@ -9,7 +9,7 @@
             <argument type="service" id="request_stack" />
         </service>
         <service id="patch_manager.operations" public="false" class="Cypress\PatchManager\Request\Operations">
-            <configurator service="patch_manager.request_adapter" method="setRequestBody" />
+            <argument type="service" id="patch_manager.request_adapter" />
         </service>
         <service id="patch_manager.operation_matcher" public="false" class="Cypress\PatchManager\OperationMatcher">
             <argument type="service" id="patch_manager.operations" />

--- a/src/PatchManager/Request/Adapter.php
+++ b/src/PatchManager/Request/Adapter.php
@@ -10,8 +10,7 @@ namespace Cypress\PatchManager\Request;
 interface Adapter
 {
     /**
-     * @param Operations $operations
-     * @return void
+     * @return null|string
      */
-    public function setRequestBody(Operations $operations);
+    public function getRequestBody(): ?string;
 }

--- a/tests/PatchManager/Bundle/RequestAdapter/RequestStackAdapterTest.php
+++ b/tests/PatchManager/Bundle/RequestAdapter/RequestStackAdapterTest.php
@@ -16,12 +16,11 @@ class RequestStackAdapterTest extends PatchManagerTestCase
         $requestStack->getCurrentRequest()->willReturn($currentRequest->reveal());
         $adapter = new RequestStackAdapter($requestStack->reveal());
 
-        $operations = new Operations();
-        $adapter->setRequestBody($operations);
+        $operations = new Operations($adapter);
 
         $this->assertCount(1, $operations->all());
 
         $first = $operations->all()->get(0);
         $this->assertEquals('data', $first['op']);
     }
-} 
+}

--- a/tests/PatchManager/Request/OperationsTest.php
+++ b/tests/PatchManager/Request/OperationsTest.php
@@ -4,6 +4,7 @@ namespace Cypress\PatchManager\Tests\Request;
 
 use Cypress\PatchManager\Exception\MissingOperationNameRequest;
 use Cypress\PatchManager\Tests\PatchManagerTestCase;
+use Cypress\PatchManager\Request\Adapter;
 use Cypress\PatchManager\Request\Operations;
 use Mockery as m;
 
@@ -14,15 +15,28 @@ class OperationsTest extends PatchManagerTestCase
      */
     public function test_request_with_invalid_json()
     {
-        $operations = new Operations();
-        $operations->setRequestBody('{"test": error}');
+        $adapter = $this->prophesize(Adapter::class);
+        $adapter->getRequestBody()->willReturn('{"test": error}');
+        $operations = new Operations($adapter->reveal());
+        $operations->all();
+    }
+
+    /**
+     * @expectedException \Cypress\PatchManager\Exception\InvalidJsonRequestContent
+     */
+    public function test_exeception_with_null_request()
+    {
+        $adapter = $this->prophesize(Adapter::class);
+        $adapter->getRequestBody()->willReturn(null);
+        $operations = new Operations($adapter->reveal());
         $operations->all();
     }
 
     public function test_correct_operations_number_with_one_operation()
     {
-        $operations = new Operations();
-        $operations->setRequestBody('{"op": "data"}');
+        $adapter = $this->prophesize(Adapter::class);
+        $adapter->getRequestBody()->willReturn('{"op": "data"}');
+        $operations = new Operations($adapter->reveal());
         $this->assertCount(1, $operations->all());
         $op = $operations->all()->get(0);
         $this->assertEquals('data', $op['op']);
@@ -30,8 +44,9 @@ class OperationsTest extends PatchManagerTestCase
 
     public function test_correct_operations_number_with_multiple_operation()
     {
-        $operations = new Operations();
-        $operations->setRequestBody('[{"op": "data"},{"op": "data2"}]');
+        $adapter = $this->prophesize(Adapter::class);
+        $adapter->getRequestBody()->willReturn('[{"op": "data"},{"op": "data2"}]');
+        $operations = new Operations($adapter->reveal());
         $this->assertCount(2, $operations->all());
         $op1 = $operations->all()->get(0);
         $this->assertEquals('data', $op1['op']);
@@ -44,8 +59,9 @@ class OperationsTest extends PatchManagerTestCase
      */
     public function test_exeception_with_empty_request()
     {
-        $operations = new Operations();
-        $operations->setRequestBody('""');
+        $adapter = $this->prophesize(Adapter::class);
+        $adapter->getRequestBody()->willReturn('""');
+        $operations = new Operations($adapter->reveal());
         $operations->all();
     }
 
@@ -54,8 +70,9 @@ class OperationsTest extends PatchManagerTestCase
      */
     public function test_exeception_with_operation_without_op()
     {
-        $operations = new Operations();
-        $operations->setRequestBody('[{"op_wrong": "data"}]');
+        $adapter = $this->prophesize(Adapter::class);
+        $adapter->getRequestBody()->willReturn('[{"op_wrong": "data"}]');
+        $operations = new Operations($adapter->reveal());
         $operations->all();
     }
 
@@ -64,8 +81,9 @@ class OperationsTest extends PatchManagerTestCase
      */
     public function test_exeception_with_multiple_operation_without_op()
     {
-        $operations = new Operations();
-        $operations->setRequestBody('[{"op": "data"},{"op_wrong": "data"}]');
+        $adapter = $this->prophesize(Adapter::class);
+        $adapter->getRequestBody()->willReturn('[{"op": "data"},{"op_wrong": "data"}]');
+        $operations = new Operations($adapter->reveal());
         $operations->all();
     }
 }


### PR DESCRIPTION
With the current implementation it is not possible to inject the `patch_manager` in a symfony controller's constructor as it would eagerly instantiate the `patch_manager.operations` service, thus getting an empty request from the request stack.

This resulted in a fatal error:
> Call to a member function getContent() on null in RequestStackAdapter.php line 29